### PR TITLE
oauth 회원가입 코드 리팩토링

### DIFF
--- a/src/main/java/com/fourdays/foodage/member/domain/Member.java
+++ b/src/main/java/com/fourdays/foodage/member/domain/Member.java
@@ -13,7 +13,6 @@ import com.fourdays.foodage.common.enums.LoginResult;
 import com.fourdays.foodage.common.enums.MemberState;
 import com.fourdays.foodage.common.enums.ResultCode;
 import com.fourdays.foodage.jwt.domain.Authority;
-import com.fourdays.foodage.member.exception.MemberInvalidStateException;
 import com.fourdays.foodage.member.exception.MemberJoinedException;
 import com.fourdays.foodage.member.exception.MemberNotJoinedException;
 import com.fourdays.foodage.oauth.domain.OauthId;
@@ -95,6 +94,7 @@ public class Member {
 	private Set<Authority> authorities;
 
 	public LoginResult getLoginResultByMemberState() {
+
 		switch (state) {
 			case TEMP_JOIN -> { // 가입 진행중
 				return LoginResult.JOIN_IN_PROGRESS;
@@ -114,16 +114,8 @@ public class Member {
 		}
 	}
 
-	public void validateMemberHasInvalidState() {
-		if (state == MemberState.BLOCK) {
-			throw new MemberInvalidStateException(ResultCode.ERR_MEMBER_INVALID, LoginResult.BLOCKED);
-		}
-		if (state == MemberState.LEAVE) {
-			throw new MemberInvalidStateException(ResultCode.ERR_MEMBER_INVALID, LoginResult.LEAVED);
-		}
-	}
-
 	public void validateMemberIsTempJoin() {
+
 		if (state != MemberState.TEMP_JOIN &&
 			nickname != null &&
 			character != null) {

--- a/src/main/java/com/fourdays/foodage/member/dto/MemberLoginResultDto.java
+++ b/src/main/java/com/fourdays/foodage/member/dto/MemberLoginResultDto.java
@@ -1,10 +1,14 @@
 package com.fourdays.foodage.member.dto;
 
 import com.fourdays.foodage.common.enums.LoginResult;
+import com.fourdays.foodage.oauth.domain.OauthId;
 
 public record MemberLoginResultDto(
 
+	OauthId oauthId,
 	String nickname,
-	LoginResult loginResult
+	String accountEmail,
+	LoginResult loginResult,
+	String credential
 ) {
 }

--- a/src/main/java/com/fourdays/foodage/member/service/MemberQueryService.java
+++ b/src/main/java/com/fourdays/foodage/member/service/MemberQueryService.java
@@ -46,6 +46,7 @@ public class MemberQueryService {
 
 		Member findMember = memberRepository.findByOauthIdAndAccountEmail(oauthId, accountEmail)
 			.orElseThrow(() -> new MemberNotJoinedException(ResultCode.ERR_MEMBER_NOT_FOUND));
+
 		log.debug(
 			"findByOauthIdAndAccountEmail (param | oauthId : {} {}, accountEmail : {})\n#--------- find member info ---------#\nid : {}\naccountEmail : {}\noauthServerType : {}\ncredential : {}\nstate : {}\n#------------------------------------#",
 			oauthId.getOauthServerType(), oauthId.getOauthServerId(), accountEmail,

--- a/src/main/java/com/fourdays/foodage/oauth/service/OauthService.java
+++ b/src/main/java/com/fourdays/foodage/oauth/service/OauthService.java
@@ -2,15 +2,9 @@ package com.fourdays.foodage.oauth.service;
 
 import org.springframework.stereotype.Service;
 
-import com.fourdays.foodage.common.enums.LoginResult;
 import com.fourdays.foodage.jwt.service.AuthService;
-import com.fourdays.foodage.member.dto.MemberLoginResultDto;
-import com.fourdays.foodage.member.exception.MemberInvalidStateException;
-import com.fourdays.foodage.member.exception.MemberJoinInProgressException;
-import com.fourdays.foodage.member.exception.MemberNotJoinedException;
 import com.fourdays.foodage.member.service.MemberCommandService;
 import com.fourdays.foodage.oauth.domain.OauthMember;
-import com.fourdays.foodage.oauth.dto.OauthLoginResponseDto;
 import com.fourdays.foodage.oauth.util.OauthLoginProviderImpl;
 import com.fourdays.foodage.oauth.util.OauthRequestUriProviderImpl;
 import com.fourdays.foodage.oauth.util.OauthServerType;
@@ -37,50 +31,19 @@ public class OauthService {
 	public String getRequestUri(OauthServerType oauthServerType) {
 
 		String requestUri = requestUriProvider.getRequestUri(oauthServerType);
-		log.debug("request uri : {}", requestUri);
+		log.debug("# request uri : {}", requestUri);
 		return requestUri;
 	}
 
-	public OauthLoginResponseDto login(OauthServerType oauthServerType, String authCode) {
+	public OauthMember getOauthMember(OauthServerType oauthServerType, String authCode) {
 
-		// 매핑되는 server의 api로 token, 사용자 정보(member info) 요청
-		OauthMember oauthMemberInfo = oauthClient.fetch(oauthServerType, authCode);
-
-		// 해당 사용자 정보가 db에 존재하는지(기존 가입 여부) 확인
-		LoginResult loginResult;
-		MemberLoginResultDto memberLoginInfo = null;
-		String credential = null;
-		try {
-			memberLoginInfo = memberCommandService.login(oauthMemberInfo.getOauthId(),
-				oauthMemberInfo.getAccountEmail());
-
-			loginResult = memberLoginInfo.loginResult();
-			credential = authService.updateCredential(
-				oauthMemberInfo.getOauthId(), oauthMemberInfo.getAccountEmail());
-
-		} catch (MemberNotJoinedException e) { // 미가입 사용자
-			// redirect시 사용자 정보를 body에 전달할 수 없어, 사용자 데이터 임시 저장한 후 update하는 방법으로 회원가입 처리
-			memberLoginInfo = memberCommandService.tempJoin(oauthMemberInfo.getOauthId(),
-				oauthMemberInfo.getAccountEmail());
-			log.debug(e.getMessage());
-			loginResult = memberLoginInfo.loginResult();
-
-		} catch (MemberJoinInProgressException e) { // 가입 진행중인 사용자
-			log.debug(e.getMessage());
-			loginResult = e.getLoginResult(); // TEMP_JOIN state
-
-		} catch (MemberInvalidStateException e) { // 서비스 접근 불가능 상태인 사용자
-			log.debug(e.getMessage());
-			loginResult = e.getLoginResult(); // BLOCK or LEAVE state
-		}
-
-		return OauthLoginResponseDto.builder()
-			.oauthServerType(oauthMemberInfo.getOauthId().getOauthServerType())
-			.accountEmail(oauthMemberInfo.getAccountEmail())
-			.accessToken(oauthMemberInfo.getAccessToken())
-			.nickname(memberLoginInfo.nickname())
-			.result(loginResult)
-			.credential(credential)
-			.build();
+		// oauth 서버에 oauth access token, 사용자 정보(member info) 요청
+		OauthMember oauthMember = oauthClient.fetch(oauthServerType, authCode);
+		log.debug("# oauth access token : {}", oauthMember.getAccessToken());
+		log.debug("# oauthServerId : {}\noauthServerType : {}\naccountEmail : {}",
+			oauthMember.getOauthId().getOauthServerId(),
+			oauthMember.getOauthId().getOauthServerType(),
+			oauthMember.getAccountEmail());
+		return oauthMember;
 	}
 }


### PR DESCRIPTION
### 작업 내용
[as-is]
- OauthService에서 login 처리
- MemberCommandService로붵 login 가능 여부 결과 전달받아 처리 (exception을 catch하는 방법으로 처리)
- OauthService login() 메소드에서 반환된 loginResult를 OauthController에서 분기 처리 각 클래스 간 책임 분리가 명확하지 않고, 관계가 꼬여있었음

[to-be]
- 각 클래스 별 책임 분리
- OauthService에서는 Oauth 사용자 정보만 조회하여 반환
- 그 외 login 로직은 MemberCommandService에서 처리
- OauthController에서는 jwt 생성 및 redirect 주소만 반환

---

### 코멘트
@jjjaehoon 님, 위 작업 내용 develop으로 머지하기 위한 pr 요청드립니다.
정상 동작 여부 확인 후 머지 부탁드립니다.
감사합니다.
